### PR TITLE
Remove Ctrl+D quit shortcut

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -194,13 +194,6 @@ impl<'a> App<'a> {
                                 }
                             }
                         }
-                        KeyEvent {
-                            code: KeyCode::Char('d'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            ..
-                        } => {
-                            self.app_event_tx.send(AppEvent::ExitRequest);
-                        }
                         _ => {
                             self.dispatch_key_event(key_event);
                         }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -629,7 +629,7 @@ impl ChatComposer<'_> {
                 }
             } else {
                 BlockState {
-                    right_title: Line::from("Enter to send | Ctrl+D to quit | Ctrl+J for newline")
+                    right_title: Line::from("Enter to send | Ctrl+C to quit | Ctrl+J for newline")
                         .alignment(Alignment::Right),
                     border_style: Style::default(),
                 }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"
-"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+C to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"
-"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+C to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"
-"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+C to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"
-"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+C to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"
-"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+C to quit | Ctrl+J for newline╯"


### PR DESCRIPTION
## Summary
- quit hint now uses Ctrl+C instead of Ctrl+D
- drop Ctrl+D handler in the app
- update bottom pane snapshots

## Testing
- `cargo fmt -- --config imports_granularity=Item` *(fails: rustfmt missing)*
- `cargo clippy --tests` *(fails: clippy missing)*
- `cargo test --quiet` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6876b4d30a3c8320aa0c8f64a925edeb